### PR TITLE
Removed IDisposable from HttpFixture in order to prevent premature di…

### DIFF
--- a/Source/Otc.AspNetCore.ApiBoot.TestHost/HttpFixture.cs
+++ b/Source/Otc.AspNetCore.ApiBoot.TestHost/HttpFixture.cs
@@ -9,11 +9,9 @@ using System.Collections.Generic;
 
 namespace Otc.AspNetCore.ApiBoot.TestHost
 {
-    public class HttpFixture<TStartup> : IDisposable
+    public class HttpFixture<TStartup>
         where TStartup : ApiBootStartup
     {
-        private List<TestServer> serverList = new List<TestServer>();
-
         public TestServer CreateServer(Action<IServiceCollection> serviceConfiguration)
         {
             var builder = WebHost.CreateDefaultBuilder()
@@ -26,18 +24,7 @@ namespace Otc.AspNetCore.ApiBoot.TestHost
                 .ConfigureServices(serviceConfiguration)
                 .UseStartup<TStartup>();
 
-            var server = new TestServer(builder);
-            serverList.Add(server);
-
-            return server;
-        }
-
-        public void Dispose()
-        {
-            foreach (var server in serverList)
-            {
-                server.Dispose();
-            }
+            return new TestServer(builder);
         }
     }
 }

--- a/Source/Otc.AspNetCore.ApiBoot.TestHost/Otc.AspNetCore.ApiBoot.TestHost.csproj
+++ b/Source/Otc.AspNetCore.ApiBoot.TestHost/Otc.AspNetCore.ApiBoot.TestHost.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2018</Copyright>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.0.4</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-aspnetcore-apiboot</PackageProjectUrl>     
   </PropertyGroup>
 

--- a/Source/Otc.AspNetCore.ApiBoot/Otc.AspNetCore.ApiBoot.csproj
+++ b/Source/Otc.AspNetCore.ApiBoot/Otc.AspNetCore.ApiBoot.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2018</Copyright>
-    <VersionPrefix>2.0.3</VersionPrefix>
+    <VersionPrefix>2.0.4</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-aspnetcore-apiboot</PackageProjectUrl>    
   </PropertyGroup>
 


### PR DESCRIPTION
Removed IDisposable from HttpFixture in order to prevent premature dispose of TestServer (occur only in linux).